### PR TITLE
Enable Async Variations of Assertion and Precondition Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ You can use XCTestExtensions in your tests. The [API documentation](https://swif
 `XCTRuntimeAssertion` for catching assertions:
 ```swift
 try XCTRuntimeAssertion {
- assertionFailure()
+    assertionFailure()
 }
 ```
 
 `XCTRuntimePrecondition` for catching preconditions:
 ```swift
 try XCTRuntimePrecondition {
- preconditionFailure()
+    preconditionFailure()
 }
 ```
+
+`XCTRuntimeAssertion` and `XCTRuntimePrecondition` also support the execution of async code.
 
 For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordBDHG/XCTRuntimeAssertions/documentation).
 

--- a/Sources/XCTRuntimeAssertions/Assert.swift
+++ b/Sources/XCTRuntimeAssertions/Assert.swift
@@ -1,8 +1,75 @@
 //
-//  File.swift
-//  
+// This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-//  Created by Paul Shmiedmayer on 7/19/23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
-import Foundation
+
+#if DEBUG || TEST
+/// Performs a traditional C-style assert with an optional message.
+///
+/// Use this function for internal sanity checks that are active during testing
+/// but do not impact performance of shipping code. To check for invalid usage
+/// in Release builds, see `precondition(_:_:file:line:)`.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration),
+///   `condition` is not evaluated, and there are no effects.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+/// - Parameters:
+///   - condition: The condition to test. `condition` is only evaluated in
+///     playgrounds and `-Onone` builds.
+///   - message: A string to print if `condition` is evaluated to `false`. The
+///     default is an empty string.
+///   - file: The file name to print with `message` if the assertion fails. The
+///     default is the file where `assert(_:_:file:line:)` is called.
+///   - line: The line number to print along with `message` if the assertion
+///     fails. The default is the line number where `assert(_:_:file:line:)`
+///     is called.
+public func assert(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTRuntimeAssertionInjector.assert(condition, message: message, file: file, line: line)
+}
+
+/// Indicates that an internal sanity check failed.
+///
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stop program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds, has no effect.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
+///
+/// - Parameters:
+///   - message: A string to print in a playground or `-Onone` build. The
+///     default is an empty string.
+///   - file: The file name to print with `message`. The default is the file
+///     where `assertionFailure(_:file:line:)` is called.
+///   - line: The line number to print along with `message`. The default is the
+///     line number where `assertionFailure(_:file:line:)` is called.
+public func assertionFailure(
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTRuntimeAssertionInjector.assert({ true }, message: message, file: file, line: line)
+}
+#endif

--- a/Sources/XCTRuntimeAssertions/Assert.swift
+++ b/Sources/XCTRuntimeAssertions/Assert.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 7/19/23.
+//
+
+import Foundation

--- a/Sources/XCTRuntimeAssertions/Counter.swift
+++ b/Sources/XCTRuntimeAssertions/Counter.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 7/19/23.
+//
+
+import Foundation

--- a/Sources/XCTRuntimeAssertions/Counter.swift
+++ b/Sources/XCTRuntimeAssertions/Counter.swift
@@ -1,8 +1,17 @@
 //
-//  File.swift
-//  
+// This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-//  Created by Paul Shmiedmayer on 7/19/23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
-import Foundation
+
+class Counter {
+    var counter: Int
+    
+    
+    init(counter: Int = 0) {
+        self.counter = counter
+    }
+}

--- a/Sources/XCTRuntimeAssertions/NeverReturn.swift
+++ b/Sources/XCTRuntimeAssertions/NeverReturn.swift
@@ -1,8 +1,19 @@
 //
-//  File.swift
-//  
+// This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-//  Created by Paul Shmiedmayer on 7/19/23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
+#if DEBUG || TEST
 import Foundation
+
+
+func neverReturn() -> Never {
+    // This is unfortunate but as far as I can see the only feasable way to return Never without calling a runtime crashing function, e.g. `fatalError()`.
+    repeat {
+        RunLoop.current.run()
+    } while (true)
+}
+#endif

--- a/Sources/XCTRuntimeAssertions/NeverReturn.swift
+++ b/Sources/XCTRuntimeAssertions/NeverReturn.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 7/19/23.
+//
+
+import Foundation

--- a/Sources/XCTRuntimeAssertions/Precondition.swift
+++ b/Sources/XCTRuntimeAssertions/Precondition.swift
@@ -1,8 +1,84 @@
 //
-//  File.swift
-//  
+// This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-//  Created by Paul Shmiedmayer on 7/19/23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
+#if DEBUG || TEST
 import Foundation
+
+
+/// Checks a necessary condition for making forward progress.
+///
+/// Use this function to detect conditions that must prevent the program from
+/// proceeding, even in shipping code.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration): If
+///   `condition` evaluates to `false`, stop program execution.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+/// - Parameters:
+///   - condition: The condition to test. `condition` is not evaluated in
+///     `-Ounchecked` builds.
+///   - message: A string to print if `condition` is evaluated to `false` in a
+///     playground or `-Onone` build. The default is an empty string.
+///   - file: The file name to print with `message` if the precondition fails.
+///     The default is the file where `precondition(_:_:file:line:)` is
+///     called.
+///   - line: The line number to print along with `message` if the assertion
+///     fails. The default is the line number where
+///     `precondition(_:_:file:line:)` is called.
+public func precondition(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTRuntimeAssertionInjector.precondition(condition, message: message, file: file, line: line)
+}
+
+/// Indicates that a precondition was violated.
+///
+/// Use this function to stop the program when control flow can only reach the
+/// call if your API was improperly used and execution flow is not expected to
+/// reach the call---for example, in the `default` case of a `switch` where
+/// you have knowledge that one of the other cases must be satisfied.
+///
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stops program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration), stops
+///   program execution.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
+///
+/// - Parameters:
+///   - message: A string to print in a playground or `-Onone` build. The
+///     default is an empty string.
+///   - file: The file name to print with `message`. The default is the file
+///     where `preconditionFailure(_:file:line:)` is called.
+///   - line: The line number to print along with `message`. The default is the
+///     line number where `preconditionFailure(_:file:line:)` is called.
+public func preconditionFailure(
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) -> Never {
+    XCTRuntimeAssertionInjector.precondition({ true }, message: message, file: file, line: line)
+    neverReturn()
+}
+#endif

--- a/Sources/XCTRuntimeAssertions/Precondition.swift
+++ b/Sources/XCTRuntimeAssertions/Precondition.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 7/19/23.
+//
+
+import Foundation

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -31,7 +31,10 @@ public func XCTRuntimeAssertion<T>(
     _ expression: @escaping () throws -> T
 ) throws -> T {
     let fulfillmentCount = Counter()
-    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(
+        fulfillmentCount: fulfillmentCount,
+        validateRuntimeAssertion: validateRuntimeAssertion
+    )
     
     var result: Result<T, Error>
     do {
@@ -79,7 +82,10 @@ public func XCTRuntimeAssertion<T>(
     _ expression: @escaping () async throws -> T
 ) async throws -> T {
     let fulfillmentCount = Counter()
-    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(
+        fulfillmentCount: fulfillmentCount,
+        validateRuntimeAssertion: validateRuntimeAssertion
+    )
     
     var result: Result<T, Error>
     do {

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -30,7 +30,84 @@ public func XCTRuntimeAssertion<T>(
     line: UInt = #line,
     _ expression: @escaping () throws -> T
 ) throws -> T {
-    var fulfillmentCount: Int = 0
+    let fulfillmentCount = Counter()
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    
+    var result: Result<T, Error>
+    do {
+        result = .success(try expression())
+    } catch {
+        result = .failure(error)
+    }
+    
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+    
+    try assertFulfillmentCount(
+        fulfillmentCount,
+        expectedFulfillmentCount: expectedFulfillmentCount,
+        message,
+        file: file,
+        line: line
+    )
+    
+    switch result {
+    case let .success(returnValue):
+        return returnValue
+    case let .failure(error):
+        throw error
+    }
+}
+
+/// `XCTRuntimeAssertion` allows you to test async assertions of types that use the `assert` and `assertionFailure` functions of the `XCTRuntimeAssertions` target.
+/// - Parameters:
+///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///                               `assert` and `assertionFailure` functions of the `XCTRuntimeAssertions` target.
+///   - expectedFulfillmentCount: The expected fulfillment count on how often the `assert` and `assertionFailure` functions of
+///                               the `XCTRuntimeAssertions` target are called. The defailt value is 1.
+///   - message: A message that is posted on failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+///   - expression: The async expression that is evaluated.
+/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+/// - Returns: The value of the function if it did not throw an error as it did not trigger a runtime assertion with the parameters defined above.
+public func XCTRuntimeAssertion<T>(
+    validateRuntimeAssertion: ((String) -> Void)? = nil,
+    expectedFulfillmentCount: Int = 1,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ expression: @escaping () async throws -> T
+) async throws -> T {
+    let fulfillmentCount = Counter()
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    
+    var result: Result<T, Error>
+    do {
+        result = .success(try await expression())
+    } catch {
+        result = .failure(error)
+    }
+    
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+    
+    try assertFulfillmentCount(
+        fulfillmentCount,
+        expectedFulfillmentCount: expectedFulfillmentCount,
+        message,
+        file: file,
+        line: line
+    )
+    
+    switch result {
+    case let .success(returnValue):
+        return returnValue
+    case let .failure(error):
+        throw error
+    }
+}
+
+
+private func setupXCTRuntimeAssertionInjector(fulfillmentCount: Counter, validateRuntimeAssertion: ((String) -> Void)? = nil) -> UUID {
     let xctRuntimeAssertionId = UUID()
     
     XCTRuntimeAssertionInjector.inject(
@@ -45,101 +122,29 @@ public func XCTRuntimeAssertion<T>(
                     // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
                     let message = message()
                     validateRuntimeAssertion?(message)
-                    fulfillmentCount += 1
+                    fulfillmentCount.counter += 1
                 }
             }
         )
     )
     
-    var result: Result<T, Error>
-    do {
-        result = .success(try expression())
-    } catch {
-        result = .failure(error)
-    }
-    
-    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
-    
-    if fulfillmentCount != expectedFulfillmentCount {
+    return xctRuntimeAssertionId
+}
+
+private func assertFulfillmentCount(
+    _ fulfillmentCount: Counter,
+    expectedFulfillmentCount: Int,
+    _ message: () -> String,
+    file: StaticString,
+    line: UInt
+) throws {
+    if fulfillmentCount.counter != expectedFulfillmentCount {
         throw XCTFail(
             message: """
-            Measured an fulfillment count of \(fulfillmentCount), expected \(expectedFulfillmentCount).
+            Measured an fulfillment count of \(fulfillmentCount.counter), expected \(expectedFulfillmentCount).
             \(message()) at \(file):\(line)
             """
         )
     }
-    
-    switch result {
-    case let .success(returnValue):
-        return returnValue
-    case let .failure(error):
-        throw error
-    }
-}
-
-
-/// Performs a traditional C-style assert with an optional message.
-///
-/// Use this function for internal sanity checks that are active during testing
-/// but do not impact performance of shipping code. To check for invalid usage
-/// in Release builds, see `precondition(_:_:file:line:)`.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration),
-///   `condition` is not evaluated, and there are no effects.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-/// - Parameters:
-///   - condition: The condition to test. `condition` is only evaluated in
-///     playgrounds and `-Onone` builds.
-///   - message: A string to print if `condition` is evaluated to `false`. The
-///     default is an empty string.
-///   - file: The file name to print with `message` if the assertion fails. The
-///     default is the file where `assert(_:_:file:line:)` is called.
-///   - line: The line number to print along with `message` if the assertion
-///     fails. The default is the line number where `assert(_:_:file:line:)`
-///     is called.
-public func assert(
-    _ condition: @autoclosure () -> Bool,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #file,
-    line: UInt = #line
-) {
-    XCTRuntimeAssertionInjector.assert(condition, message: message, file: file, line: line)
-}
-
-/// Indicates that an internal sanity check failed.
-///
-/// This function's effect varies depending on the build flag used:
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration), stop program execution in a debuggable state after
-///   printing `message`.
-///
-/// * In `-O` builds, has no effect.
-///
-/// * In `-Ounchecked` builds, the optimizer may assume that this function is
-///   never called. Failure to satisfy that assumption is a serious
-///   programming error.
-///
-/// - Parameters:
-///   - message: A string to print in a playground or `-Onone` build. The
-///     default is an empty string.
-///   - file: The file name to print with `message`. The default is the file
-///     where `assertionFailure(_:file:line:)` is called.
-///   - line: The line number to print along with `message`. The default is the
-///     line number where `assertionFailure(_:file:line:)` is called.
-public func assertionFailure(
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #file,
-    line: UInt = #line
-) {
-    XCTRuntimeAssertionInjector.assert({ true }, message: message, file: file, line: line)
 }
 #endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -26,12 +26,87 @@ public func XCTRuntimePrecondition(
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line,
-    _ expression: @escaping () throws -> Void
+    _ expression: @escaping () -> Void
 ) throws {
-    let xctRuntimeAssertionId = UUID()
+    let fulfillmentCount = Counter()
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    
     // We have to run the operation on a `DispatchQueue` as we have to call `RunLoop.current.run()` in the `preconditionFailure` call.
     let dispatchQueue = DispatchQueue(label: "XCTRuntimePrecondition-\(xctRuntimeAssertionId)")
-    var fulfillmentCount: Int = 0
+    
+    let expressionWorkItem = DispatchWorkItem {
+        expression()
+    }
+    dispatchQueue.async(execute: expressionWorkItem)
+    
+    // We don't use:
+    // `wait(for: [expectation], timeout: timeout)`
+    // here as we need to make the method independent of XCTestCase to also use it in our TestApp UITest target which fails if you import XCTest.
+    usleep(useconds_t(1_000_000 * timeout))
+    expressionWorkItem.cancel()
+    
+    try assertFulfillmentCount(
+        fulfillmentCount,
+        message,
+        file: file,
+        line: line
+    )
+    
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+}
+
+/// `XCTRuntimePrecondition` allows you to test async assertions of types that use the `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
+/// - Parameters:
+///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///                               `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
+///   - timeout: A timeout defining how long to wait for the precondition to be triggered.
+///   - message: A message that is posted on failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+///   - expression: The async expression that is evaluated.
+/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+public func XCTRuntimePrecondition(
+    validateRuntimeAssertion: ((String) -> Void)? = nil,
+    timeout: Double = 0.01,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ expression: @escaping () async -> Void
+) throws {
+    let fulfillmentCount = Counter()
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    
+    // We have to run the operation on a `DispatchQueue` as we have to call `RunLoop.current.run()` in the `preconditionFailure` call.
+    let dispatchQueue = DispatchQueue(label: "XCTRuntimePrecondition-\(xctRuntimeAssertionId)")
+    
+    var task: Task<Void, Never>?
+    let expressionWorkItem = DispatchWorkItem {
+        task = Task {
+            await expression()
+        }
+    }
+    dispatchQueue.async(execute: expressionWorkItem)
+    
+    // We don't use:
+    // `wait(for: [expectation], timeout: timeout)`
+    // here as we need to make the method independent of XCTestCase to also use it in our TestApp UITest target which fails if you import XCTest.
+    usleep(useconds_t(1_000_000 * timeout))
+    expressionWorkItem.cancel()
+    task?.cancel()
+    
+    try assertFulfillmentCount(
+        fulfillmentCount,
+        message,
+        file: file,
+        line: line
+    )
+    
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+}
+
+
+private func setupXCTRuntimeAssertionInjector(fulfillmentCount: Counter, validateRuntimeAssertion: ((String) -> Void)? = nil) -> UUID {
+    let xctRuntimeAssertionId = UUID()
     
     XCTRuntimeAssertionInjector.inject(
         runtimeAssertionInjector: XCTRuntimeAssertionInjector(
@@ -45,27 +120,30 @@ public func XCTRuntimePrecondition(
                     // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
                     let message = message()
                     validateRuntimeAssertion?(message)
-                    fulfillmentCount += 1
+                    fulfillmentCount.counter += 1
                     neverReturn()
                 }
             }
         )
     )
     
-    let expressionWorkItem = DispatchWorkItem {
-        do {
-            try expression()
-        } catch {}
-    }
-    dispatchQueue.async(execute: expressionWorkItem)
-    
-    // We don't use:
-    // `wait(for: [expectation], timeout: timeout)`
-    // here as we need to make the method independent of XCTestCase to also use it in our TestApp UITest target which fails if you import XCTest.
-    usleep(useconds_t(1_000_000 * timeout))
-    expressionWorkItem.cancel()
-    
-    if fulfillmentCount != 1 {
+    return xctRuntimeAssertionId
+}
+
+private func assertFulfillmentCount(
+    _ fulfillmentCount: Counter,
+    _ message: () -> String,
+    file: StaticString,
+    line: UInt
+) throws {
+    if fulfillmentCount.counter <= 0 {
+        throw XCTFail(
+            message: """
+            The precondition was never called.
+            \(message()) at \(file):\(line)
+            """
+        )
+    } else if fulfillmentCount.counter > 1 {
         throw XCTFail(
             message: """
             The precondition was called multiple times.
@@ -73,86 +151,5 @@ public func XCTRuntimePrecondition(
             """
         )
     }
-    
-    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
-}
-
-private func neverReturn() -> Never {
-    // This is unfortunate but as far as I can see the only feasable way to return Never without calling a runtime crashing function, e.g. `fatalError()`.
-    repeat {
-        RunLoop.current.run()
-    } while (true)
-}
-
-/// Checks a necessary condition for making forward progress.
-///
-/// Use this function to detect conditions that must prevent the program from
-/// proceeding, even in shipping code.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration): If
-///   `condition` evaluates to `false`, stop program execution.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-/// - Parameters:
-///   - condition: The condition to test. `condition` is not evaluated in
-///     `-Ounchecked` builds.
-///   - message: A string to print if `condition` is evaluated to `false` in a
-///     playground or `-Onone` build. The default is an empty string.
-///   - file: The file name to print with `message` if the precondition fails.
-///     The default is the file where `precondition(_:_:file:line:)` is
-///     called.
-///   - line: The line number to print along with `message` if the assertion
-///     fails. The default is the line number where
-///     `precondition(_:_:file:line:)` is called.
-public func precondition(
-    _ condition: @autoclosure () -> Bool,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #file,
-    line: UInt = #line
-) {
-    XCTRuntimeAssertionInjector.precondition(condition, message: message, file: file, line: line)
-}
-
-/// Indicates that a precondition was violated.
-///
-/// Use this function to stop the program when control flow can only reach the
-/// call if your API was improperly used and execution flow is not expected to
-/// reach the call---for example, in the `default` case of a `switch` where
-/// you have knowledge that one of the other cases must be satisfied.
-///
-/// This function's effect varies depending on the build flag used:
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration), stops program execution in a debuggable state after
-///   printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration), stops
-///   program execution.
-///
-/// * In `-Ounchecked` builds, the optimizer may assume that this function is
-///   never called. Failure to satisfy that assumption is a serious
-///   programming error.
-///
-/// - Parameters:
-///   - message: A string to print in a playground or `-Onone` build. The
-///     default is an empty string.
-///   - file: The file name to print with `message`. The default is the file
-///     where `preconditionFailure(_:file:line:)` is called.
-///   - line: The line number to print along with `message`. The default is the
-///     line number where `preconditionFailure(_:file:line:)` is called.
-public func preconditionFailure(
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #file,
-    line: UInt = #line
-) -> Never {
-    XCTRuntimeAssertionInjector.precondition({ true }, message: message, file: file, line: line)
-    neverReturn()
 }
 #endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -29,7 +29,10 @@ public func XCTRuntimePrecondition(
     _ expression: @escaping () -> Void
 ) throws {
     let fulfillmentCount = Counter()
-    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(
+        fulfillmentCount: fulfillmentCount,
+        validateRuntimeAssertion: validateRuntimeAssertion
+    )
     
     // We have to run the operation on a `DispatchQueue` as we have to call `RunLoop.current.run()` in the `preconditionFailure` call.
     let dispatchQueue = DispatchQueue(label: "XCTRuntimePrecondition-\(xctRuntimeAssertionId)")
@@ -74,7 +77,10 @@ public func XCTRuntimePrecondition(
     _ expression: @escaping () async -> Void
 ) throws {
     let fulfillmentCount = Counter()
-    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(fulfillmentCount: fulfillmentCount, validateRuntimeAssertion: validateRuntimeAssertion)
+    let xctRuntimeAssertionId = setupXCTRuntimeAssertionInjector(
+        fulfillmentCount: fulfillmentCount,
+        validateRuntimeAssertion: validateRuntimeAssertion
+    )
     
     let task = Task {
         await expression()

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTRuntimeAssertions"
+               BuildableName = "XCTRuntimeAssertions"
+               BlueprintName = "XCTRuntimeAssertions"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:UITests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F6D13AB28F5F386007C25D6"
+               BuildableName = "TestAppUITests.xctest"
+               BlueprintName = "TestAppUITests"
+               ReferencedContainer = "container:UITests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:UITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:UITests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -1,8 +1,84 @@
 //
-//  File.swift
-//  
+// This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-//  Created by Paul Shmiedmayer on 7/19/23.
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
-import Foundation
+import XCTest
+@testable import XCTRuntimeAssertions
+
+
+final class XCTRuntimePreconditionsTests: XCTestCase {
+    func testXCTRuntimePrecondition() throws {
+        let expectation = XCTestExpectation(description: "validateRuntimeAssertion")
+        expectation.assertForOverFulfill = true
+        
+        let number = 42
+        
+        try XCTRuntimePrecondition(
+            validateRuntimeAssertion: {
+                XCTAssertEqual("preconditionFailure()", $0)
+                expectation.fulfill()
+            },
+            "testXCTRuntimePrecondition"
+        ) {
+            precondition(number == 42, "preconditionFailure()")
+        }
+        
+        wait(for: [expectation], timeout: 0.01)
+        
+        
+        try XCTRuntimePrecondition(validateRuntimeAssertion: { XCTAssertEqual($0, "") }) {
+            preconditionFailure()
+        }
+        
+        try XCTRuntimePrecondition {
+            preconditionFailure()
+        }
+    }
+    
+    func testAsyncXCTRuntimePrecondition() throws {
+        let expectation = XCTestExpectation(description: "validateRuntimePrecondition")
+        expectation.assertForOverFulfill = true
+        
+        try XCTRuntimePrecondition(
+            validateRuntimeAssertion: {
+                XCTAssertEqual($0, "preconditionFailure()")
+                expectation.fulfill()
+            },
+            timeout: 0.5,
+            "testXCTRuntimePrecondition"
+        ) {
+            try? await Task.sleep(for: .seconds(0.02))
+            preconditionFailure("preconditionFailure()")
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testXCTRuntimePreconditionNotTriggered() async throws {
+        struct XCTRuntimePreconditionNotTriggeredError: Error {}
+        
+        do {
+            try XCTRuntimePrecondition {
+                print("Hello Paul 👋")
+            }
+        } catch let error as XCTFail {
+            XCTAssertTrue(error.message.contains("The precondition was never called."))
+        }
+        
+        do {
+            try XCTRuntimePrecondition {
+                Task {
+                    preconditionFailure()
+                }
+                preconditionFailure()
+            }
+        } catch let error as XCTFail {
+            try? await Task.sleep(for: .seconds(0.5))
+            XCTAssertTrue(error.description.contains("The precondition was never called."))
+        }
+    }
+}

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Shmiedmayer on 7/19/23.
+//
+
+import Foundation


### PR DESCRIPTION
# Enables Async Variations of Assertion and Precondition Tests

## :recycle: Current situation & Problem
- Assertion and precondition tests could not be run in an async context.

## :bulb: Proposed solution
- Adds async overloads to the testing functions
- Simplifies the internal assertion checking
- Removes the possibility to test a throwing precondition function as errors will not be caught and reported


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

