### PR TITLE
Forward to Swift runtime assertions if nothing is injected

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ XCTRuntimeAssertions contributors
 ====================
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
+* [Andreas Bauer](https://github.com/Supereg)

--- a/Sources/XCTRuntimeAssertions/Counter.swift
+++ b/Sources/XCTRuntimeAssertions/Counter.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Sources/XCTRuntimeAssertions/NeverReturn.swift
+++ b/Sources/XCTRuntimeAssertions/NeverReturn.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford XCTRuntimeAssertions open-source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -149,7 +149,7 @@ private func assertFulfillmentCount(
     if fulfillmentCount.counter != expectedFulfillmentCount {
         throw XCTFail(
             message: """
-                     The assertion fulfillment count is \(fulfillmentCount.counter), expected \(expectedFulfillmentCount).
+                     Measured an fulfillment count of \(fulfillmentCount.counter), expected \(expectedFulfillmentCount).
                      \(message()) at \(file):\(line)
                      """
         )

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -137,6 +137,7 @@ private func setupXCTRuntimeAssertionInjector(fulfillmentCount: Counter, validat
     return xctRuntimeAssertionId
 }
 
+
 private func assertFulfillmentCount(
     _ fulfillmentCount: Counter,
     expectedFulfillmentCount: UInt,

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
@@ -35,8 +35,8 @@ class XCTRuntimeAssertionInjector {
     ) {
         self.id = id
         self._assert = assert
-        self._precondition = { _, condition, messsage, file, line in
-            Swift.precondition(condition(), messsage(), file: file, line: line)
+        self._precondition = { _, condition, message, file, line in
+            Swift.precondition(condition(), message(), file: file, line: line)
         }
     }
     
@@ -45,8 +45,8 @@ class XCTRuntimeAssertionInjector {
         precondition: @escaping (UUID, () -> Bool, () -> String, StaticString, UInt) -> Void
     ) {
         self.id = id
-        self._assert = { _, condition, messsage, file, line in
-            Swift.assert(condition(), messsage(), file: file, line: line)
+        self._assert = { _, condition, message, file, line in
+            Swift.assert(condition(), message(), file: file, line: line)
         }
         self._precondition = precondition
     }
@@ -55,11 +55,11 @@ class XCTRuntimeAssertionInjector {
         id: UUID
     ) {
         self.id = id
-        self._assert = { _, condition, messsage, file, line in
-            Swift.assert(condition(), messsage(), file: file, line: line)
+        self._assert = { _, condition, message, file, line in
+            Swift.assert(condition(), message(), file: file, line: line)
         }
-        self._precondition = { _, condition, messsage, file, line in
-            Swift.precondition(condition(), messsage(), file: file, line: line)
+        self._precondition = { _, condition, message, file, line in
+            Swift.precondition(condition(), message(), file: file, line: line)
         }
     }
     
@@ -74,12 +74,20 @@ class XCTRuntimeAssertionInjector {
     
     
     static func assert(_ condition: () -> Bool, message: () -> String, file: StaticString, line: UInt) {
+        if injected.isEmpty {
+            Swift.assert(condition(), message(), file: file, line: line)
+        }
+
         for runtimeAssertionInjector in injected {
             runtimeAssertionInjector._assert(runtimeAssertionInjector.id, condition, message, file, line)
         }
     }
     
     static func precondition(_ condition: () -> Bool, message: () -> String, file: StaticString, line: UInt) {
+        if injected.isEmpty {
+            Swift.precondition(condition(), message(), file: file, line: line)
+        }
+
         for runtimeAssertionInjector in injected {
             runtimeAssertionInjector._precondition(runtimeAssertionInjector.id, condition, message, file, line)
         }

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -12,14 +12,14 @@ import Foundation
 
 /// `XCTRuntimePrecondition` allows you to test assertions of types that use the `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
 /// - Parameters:
-///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///   - validateRuntimeAssertion: An optional closure that can be used to further validate the messages passed to the
 ///                               `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
 ///   - timeout: A timeout defining how long to wait for the precondition to be triggered.
 ///   - message: A message that is posted on failure.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 ///   - expression: The expression that is evaluated.
-/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+/// - Throws: Throws an `XCTFail` error if the expression does not trigger a runtime assertion with the parameters defined above.
 public func XCTRuntimePrecondition(
     validateRuntimeAssertion: ((String) -> Void)? = nil,
     timeout: Double = 0.01,
@@ -48,26 +48,26 @@ public func XCTRuntimePrecondition(
     usleep(useconds_t(1_000_000 * timeout))
     expressionWorkItem.cancel()
     
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+
     try assertFulfillmentCount(
         fulfillmentCount,
         message,
         file: file,
         line: line
     )
-    
-    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
 }
 
 /// `XCTRuntimePrecondition` allows you to test async assertions of types that use the `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
 /// - Parameters:
-///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///   - validateRuntimeAssertion: An optional closure that can be used to further validate the messages passed to the
 ///                               `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
 ///   - timeout: A timeout defining how long to wait for the precondition to be triggered.
 ///   - message: A message that is posted on failure.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 ///   - expression: The async expression that is evaluated.
-/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+/// - Throws: Throws an `XCTFail` error if the expression does not trigger a runtime assertion with the parameters defined above.
 public func XCTRuntimePrecondition(
     validateRuntimeAssertion: ((String) -> Void)? = nil,
     timeout: Double = 0.01,
@@ -92,14 +92,14 @@ public func XCTRuntimePrecondition(
     usleep(useconds_t(1_000_000 * timeout))
     task.cancel()
     
+    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
+
     try assertFulfillmentCount(
         fulfillmentCount,
         message,
         file: file,
         line: line
     )
-    
-    XCTRuntimeAssertionInjector.removeRuntimeAssertionInjector(withId: xctRuntimeAssertionId)
 }
 
 

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -75,7 +75,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 0.1)
     }
     
-    func testXCTRuntimeAssertationNotTriggered() throws {
+    func testXCTRuntimeAssertionNotTriggered() throws {
         struct XCTRuntimeAssertionNotTriggeredError: Error {}
         
         do {
@@ -94,5 +94,16 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
         } catch let error as XCTFail {
             XCTAssertTrue(error.description.contains("Measured an fulfillment count of 0, expected 1."))
         }
+    }
+
+    func testCallHappensWithoutInjection() {
+        var called = false
+
+        assert({
+            called = true
+            return true
+        }(), "This could fail")
+
+        XCTAssertTrue(called, "assert was never called!")
     }
 }

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -81,4 +81,15 @@ final class XCTRuntimePreconditionsTests: XCTestCase {
             XCTAssertTrue(error.description.contains("The precondition was called multiple times."))
         }
     }
+
+    func testCallHappensWithoutInjection() {
+        var called = false
+
+        precondition({
+            called = true
+            return true
+        }(), "This could fail")
+
+        XCTAssertTrue(called, "precondition was never called!")
+    }
 }

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -26,7 +26,7 @@ final class XCTRuntimePreconditionsTests: XCTestCase {
         ) {
             precondition(number == 42, "preconditionFailure()")
         }
-        
+
         wait(for: [expectation], timeout: 0.01)
         
         

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -78,7 +78,7 @@ final class XCTRuntimePreconditionsTests: XCTestCase {
             }
         } catch let error as XCTFail {
             try? await Task.sleep(for: .seconds(0.5))
-            XCTAssertTrue(error.description.contains("The precondition was never called."))
+            XCTAssertTrue(error.description.contains("The precondition was called multiple times."))
         }
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Forward to Swift runtime assertions if nothing is injected

## :recycle: Current situation & Problem
Currently, when no preconditions or assertions are injected just nothing is called (or in the case of `preconditionFailure` we just **silently never return**).
This causes confusion in e.g. test environments when a `preconditionFailure` is called in code (though unexpected) and the thread just halts forever.

## :bulb: Proposed solution
This PR resolves this issue by just restoring the default behavior if no runtime assertions are injected.

## :gear: Release Notes 
* Ensure runtime assertions are forwarded as usual if nothing is injected.

## :heavy_plus_sign: Additional Information
This PR does some other, slight modifications. E.g., enforcing some bounds on `expectedFulfillmentCount`.

### Related PRs
--

### Testing
Tests for both cases were included!

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

