### PR TITLE
Fix broken implementation of `precondition` and `assert`

### DIFF
--- a/Sources/XCTRuntimeAssertions/Assert.swift
+++ b/Sources/XCTRuntimeAssertions/Assert.swift
@@ -70,6 +70,6 @@ public func assertionFailure(
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    XCTRuntimeAssertionInjector.assert({ true }, message: message, file: file, line: line)
+    XCTRuntimeAssertionInjector.assert({ false }, message: message, file: file, line: line)
 }
 #endif

--- a/Sources/XCTRuntimeAssertions/Precondition.swift
+++ b/Sources/XCTRuntimeAssertions/Precondition.swift
@@ -78,7 +78,7 @@ public func preconditionFailure(
     file: StaticString = #file,
     line: UInt = #line
 ) -> Never {
-    XCTRuntimeAssertionInjector.precondition({ true }, message: message, file: file, line: line)
+    XCTRuntimeAssertionInjector.precondition({ false }, message: message, file: file, line: line)
     neverReturn()
 }
 #endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -124,7 +124,7 @@ private func setupXCTRuntimeAssertionInjector(fulfillmentCount: Counter, validat
                     return
                 }
                 
-                if condition() {
+                if !condition() {
                     // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
                     let message = message()
                     validateRuntimeAssertion?(message)

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -114,7 +114,7 @@ private func setupXCTRuntimeAssertionInjector(fulfillmentCount: Counter, validat
                     return
                 }
                 
-                if condition() {
+                if !condition() {
                     // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
                     let message = message()
                     validateRuntimeAssertion?(message)

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -31,8 +31,8 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
             "testXCTRuntimeAssertion"
         ) {
             assertionFailure(messages[0])
-            assert(true, messages[1])
-            assert(number == 42, messages[2])
+            assert(false, messages[1])
+            assert(number != 42, messages[2])
         }
         
         XCTAssertEqual(messages, collectedMessages)

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -24,7 +24,7 @@ final class XCTRuntimePreconditionsTests: XCTestCase {
             },
             "testXCTRuntimePrecondition"
         ) {
-            precondition(number == 42, "preconditionFailure()")
+            precondition(number != 42, "preconditionFailure()")
         }
         
         wait(for: [expectation], timeout: 0.01)


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fix broken implementation of `precondition` and `assert`

## :recycle: Current situation & Problem
The implementation of `precondition` and `assert` were effectively broken. They basically flipped the condition in comparison to apples `precondition` and `assert`. The behavior was even test wrongfully.

Here are some examples:

```swift
assert(true, "This will not fail with Swift.assert")
assert(true, "This will fail with XCTRuntimeAssertions.assert")
assert(false, "This will fail with Swift.assert")
assert(true, "This will not fail with XCTRuntimeAssertions.assert")
```

This is dual to `precondition`. The usage of `preconditionFailure` and `assertFailure` was save as `XCTRuntimeAssertions` passed the wrong flag internally.

## :bulb: Proposed solution
This PR fixes this behavior by correcting the respective checks.

## :gear: Release Notes 
* Fixes an issue with `assert` and `precondition` not triggering properly or wrongfully.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Tests were addresses respectively.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

