### PR TITLE
Lie to the Swift compiler about isolation

### DIFF
--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -106,4 +106,20 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
 
         XCTAssertTrue(called, "assert was never called!")
     }
+
+    @MainActor
+    func testActorAnnotatedClosure() throws {
+        @MainActor
+        class Test {
+            var property = "Hello World"
+
+            nonisolated init() {}
+        }
+
+        let test = Test()
+
+        try XCTRuntimeAssertion {
+            assert(test.property != "Hello World", "Failed successfully")
+        }
+    }
 }

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimePreconditionsTests.swift
@@ -92,4 +92,18 @@ final class XCTRuntimePreconditionsTests: XCTestCase {
 
         XCTAssertTrue(called, "precondition was never called!")
     }
+
+    @MainActor
+    func testAsyncInvocationOnMainActor() throws {
+        @MainActor
+        class Test {
+            var property = "Hello World"
+        }
+
+        let test = Test()
+
+        try XCTRuntimePrecondition {
+            precondition(test.property != "Hello World", "Failed successfully.")
+        }
+    }
 }


### PR DESCRIPTION
# Lie to the Swift compiler about isolation

## :recycle: Current situation & Problem
In PR #14 we truthfully implemented strict concurrency checking for the XCTRuntimeAssertions library. However, this made it impossible to test runtime precondition failures on the `@MainActor` as it would completely block the actor (or the Task would only be scheduled after the `XCTRuntimePrecondition` call returned).
Therefore, it is necessary to always run `XCTRuntimePrecondition` expressions on a background thread. If we would keep correct `@Sendable` annotations for the expression closure, this would make it impossible to run `XCTRuntimePrecondition`s on the `@MainActor`. Therefore, we lie to the compiler. We deliberately don't annotate the expression closure as `@Sendable` and silence the respective concurrency warning.
The impact of that is documented.

## :gear: Release Notes 
* Restore testing preconditions which are annotated to be isolated to the `@MainActor`.


## :books: Documentation
Add documentation bubbles to explain the impact.


## :white_check_mark: Testing
Add unit testing to prevent regressions.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
