### PR TITLE
Be less strict about the requested SwiftLint version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
     } else {
         []
     }


### PR DESCRIPTION
# Be less strict about the requested SwiftLint version

## :recycle: Current situation & Problem
We currently fixed SwiftLint at `upToNextMinor`. This makes it harder for projects depending on XCTRuntimeAssertions to upgrade their swiftlint version (and SwiftSyntax version). Also the CI always uses the latest version. Therefore, we accept just any 0.x release.


## :gear: Release Notes 
* Be less strict about the requested SwiftLint version


## :books: Documentation
--


## :white_check_mark: Testing
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
