### PR TITLE
Slightly increase the default timeout for precondition assertions

### DIFF
--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -27,7 +27,7 @@ import Foundation
 /// - Throws: Throws an `XCTFail` error if the expression does not trigger a runtime assertion with the parameters defined above.
 public func XCTRuntimePrecondition(
     validateRuntimeAssertion: ((String) -> Void)? = nil,
-    timeout: TimeInterval = 0.01,
+    timeout: TimeInterval = 1,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line,
@@ -80,7 +80,7 @@ public func XCTRuntimePrecondition(
 /// - Throws: Throws an `XCTFail` error if the expression does not trigger a runtime assertion with the parameters defined above.
 public func XCTRuntimePrecondition(
     validateRuntimeAssertion: ((String) -> Void)? = nil,
-    timeout: TimeInterval = 0.01,
+    timeout: TimeInterval = 1,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line,


### PR DESCRIPTION
# Slightly increase the default timeout for precondition assertions

## :recycle: Current situation & Problem
This PR increases the default timeout from 0.01s  to 1s. In the last few days, tests were sometimes failing as XCTRuntimePrecondition failed to result in a precondition in the specified timeout. Therefore, we increase the default timeout to a less restrictive value.

## :gear: Release Notes 
* Increase default timeout from 0.01s  to 1s for XCTRuntimePrecondition.


## :books: Documentation
--


## :white_check_mark: Testing
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
